### PR TITLE
fix: allow security group to not be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Feature: DocDB Global cluster.
 - fix CKV2_AWS_5: "Ensure that Security Groups are attached to another resource"
+- fix security group association if `var.create_security_group` is `false`
 
 ## [1.3.2] - 2023-11-23
 - fix: usage of cluster_identifier_prefix

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_docdb_cluster" "this" {
   snapshot_identifier             = var.snapshot_identifier
   storage_encrypted               = var.storage_encrypted
   tags                            = var.tags
-  vpc_security_group_ids          = compact(concat(var.vpc_security_group_ids, [aws_security_group.this[0].id]))
+  vpc_security_group_ids          = compact(concat(var.vpc_security_group_ids, aws_security_group.this[*].id))
 
   timeouts {
     create = try(var.cluster_timeouts["create"], "90m")


### PR DESCRIPTION
# Description

Without this change, Terraform fails because index `0` does not exist.

## Features/Fixes/Patches/Changes list:

- fix security group association if `var.create_security_group` is `false`

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [ ] Have you followed the guidelines in our Contributing document? -> which ones?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [ ] OWNER: Does your submission pass?
    * [ ] Pre-commit (attach logs/print screen to this PR)
    * [ ] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally? -> with my own production workspace, yes

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
